### PR TITLE
Access wrapped macro as optional.

### DIFF
--- a/macro-folders.js
+++ b/macro-folders.js
@@ -71,13 +71,13 @@ function defineClasses(){
             return this.data;
         }
         get visible(){
-            return this.macro.visible;
+            return this.macro?.visible;
         }
         get name(){
             return this.data.name
         }
         get sheet(){
-            return this.macro.sheet;
+            return this.macro?.sheet;
         }
     }
     class MacroFolderCollection extends WorldCollection{


### PR DESCRIPTION
The error when deleting a Macro from the Hotbar is caused by the non-optional access to MacroEntry.macro within MacroEntry.visible()

When accessing the underlying macro as optional the issue can bes solved. I assumed that treating visible and sheet for a deleted macro as undefined is feasible - but you can assess this better than me.